### PR TITLE
FIX: Add temporary styles for chat embeds

### DIFF
--- a/assets/stylesheets/lazy-videos.scss
+++ b/assets/stylesheets/lazy-videos.scss
@@ -132,3 +132,41 @@
     border-radius: 9px;
   }
 }
+
+// Temporary styles until we support chat
+
+.chat-message-content .lazy-video-container {
+  padding: 0;
+  margin-bottom: 0;
+  background-color: transparent;
+  object-fit: contain;
+  height: 175px;
+  text-overflow: ellipsis;
+
+  &::before {
+    content: attr(data-provider-name) " | " attr(data-video-title);
+    text-transform: capitalize;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block;
+    height: 25px;
+  }
+
+  a {
+    display: block;
+    height: 150px;
+
+    img {
+      height: 100%;
+      pointer-events: none;
+    }
+  }
+}
+
+.ytp-thumbnail-image {
+  max-height: 150px !important;
+  width: unset !important;
+  pointer-events: none !important;
+  display: block;
+}


### PR DESCRIPTION
Since we don't have support for lazy embeds in chat yet, thumbnail images from the cooked elements overflow quite badly. This is a temporary fix to avoid breaking chat while we test the plugin.
I'll drop these changes and add proper support in a future PR, when we move this into core.