### PR TITLE
FIX: Old videos do not have high res thumbnails

### DIFF
--- a/lib/lazy-videos/lazy_youtube.rb
+++ b/lib/lazy-videos/lazy_youtube.rb
@@ -12,7 +12,10 @@ class Onebox::Engine::YoutubeOnebox
       result = parse_embed_response
       result ||= get_opengraph.data
 
-      thumbnail_url = "https://img.youtube.com/vi/#{video_id}/maxresdefault.jpg" || result[:image]
+      thumbnail_url = "https://img.youtube.com/vi/#{video_id}/maxresdefault.jpg"
+      thumbnail_response = Net::HTTP.get_response(URI(thumbnail_url))
+      thumbnail_url = result[:image] if !thumbnail_response.kind_of?(Net::HTTPSuccess)
+
       escaped_title = ERB::Util.html_escape(video_title)
 
       <<~HTML


### PR DESCRIPTION
Not all videos have a `/maxresdefault.jpg` thumbnail, so the URL returned 404 for some.
Now it will check if the higher res image exists and default to `/hqdefault.jpg` if it doesn't.