### PR TITLE
UX: avoid onebox CSS overriding youtube video height

### DIFF
--- a/assets/stylesheets/lazy-videos.scss
+++ b/assets/stylesheets/lazy-videos.scss
@@ -133,6 +133,11 @@
   }
 }
 
+// Overrides core onebox height: auto; that can cause a conflict
+.lazy-video-wrapper .lazy-video-container.youtube-onebox {
+  height: 0;
+}
+
 // Temporary styles until we support chat
 
 .chat-message-content .lazy-video-container {


### PR DESCRIPTION
The height set here: https://github.com/discourse/discourse/blob/94044591881cd11b71b2b98652e771ab0027fa71/app/assets/stylesheets/common/base/onebox.scss#L920 can sometimes override the height set by the plugin, so this more specific class selector ensures that can't happen. 

![image](https://github.com/discourse/discourse-lazy-videos/assets/1681963/91a1583d-9233-4f79-8d54-c6417a92a078)

